### PR TITLE
fix: Remove non existing file from cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@
 #
 # @author  Roman Zelinskyi <lord.zelinskyi@gmail.com>
 
-add_library(resource-mgr SHARED resource_manager.cpp allocator.cpp error.cpp
-                                user.cpp)
+add_library(resource-mgr SHARED resource_manager.cpp allocator.cpp user.cpp)
 
 target_include_directories(resource-mgr PRIVATE ${CMAKE_SOURCE_DIR}/include)


### PR DESCRIPTION
After replacing the custom error with std it was
forgoten to remove this file from cmake.

Signed-off-by: Roman Zelinskyi <lord.zelinskyi@gmail.com>