### PR TITLE
build: Add default release build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(resource-manager CXX)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 set(CXX_EXTENSIONS OFF)

--- a/cmake/Option.cmake
+++ b/cmake/Option.cmake
@@ -2,4 +2,16 @@
 #
 # @author  Roman Zelinskyi <lord.zelinskyi@gmail.com>
 
-option(TESTS "Enable/disable the tests" ON)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option(TESTS "Enable/disable tests" ON)
+endif()
+
+function(printOption name value)
+    if(${value})
+        message(STATUS "${name}: ON")
+    else()
+        message(STATUS "${name}: OFF")
+    endif()
+endfunction()
+
+printOption("Tests" TESTS)


### PR DESCRIPTION
Added option that checks if build type was set
and if it is not then set it to Release.

Signed-off-by: Roman Zelinskyi <lord.zelinskyi@gmail.com>