### PR TITLE
build: Add tests custom target

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,6 @@
 #
 # @author  Roman Zelinskyi <lord.zelinskyi@gmail.com>
 
+add_custom_target(tests)
+
 add_subdirectory(unit-tests)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -4,9 +4,10 @@
 
 find_package(GTest REQUIRED)
 
-add_executable(unit-tests main.cpp allocator_unit_test.cpp
-                          resource_user_unit_test.cpp
-                          resource_manager_unit_test.cpp)
+add_executable(
+  unit-tests EXCLUDE_FROM_ALL
+  main.cpp allocator_unit_test.cpp resource_user_unit_test.cpp
+  resource_manager_unit_test.cpp)
 
 target_include_directories(
   unit-tests PRIVATE ${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include
@@ -16,3 +17,5 @@ target_link_libraries(unit-tests PRIVATE ${GTEST_LIBRARIES} pthread
                                          resource-mgr)
 
 gtest_add_tests(TARGET unit-tests)
+
+add_dependencies(tests unit-tests)


### PR DESCRIPTION
Added custom target tests in order to isolate from
the user, the type of tests to be built.

Signed-off-by: Roman Zelinskyi <lord.zelinskyi@gmail.com>